### PR TITLE
chore: support esm + cjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jsonpath-rfc9535",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jsonpath-rfc9535",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@biomejs/biome": "1.9.4",

--- a/package.json
+++ b/package.json
@@ -19,16 +19,29 @@
     "dist"
   ],
   "type": "module",
-  "types": "./dist/index.d.ts",
-  "module": "./dist/index.js",
+  "types": "./dist/esm/index.d.ts",
+  "module": "./dist/esm/index.js",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/index.d.ts",
+        "default": "./dist/commonjs/index.js"
+      }
     },
+    "./package.json": "./package.json",
     "./parser": {
-      "types": "./dist/parser/index.d.ts",
-      "import": "./dist/parser/index.js"
+      "import": {
+        "types": "./dist/esm/parser/index.d.ts",
+        "default": "./dist/esm/parser/index.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/parser/index.d.ts",
+        "default": "./dist/commonjs/parser/index.js"
+      }
     }
   },
   "sideEffects": false,
@@ -39,7 +52,9 @@
     "url": "https://github.com/P0lip/jsonpath-rfc9535"
   },
   "scripts": {
-    "build": "tsc --outDir dist",
+    "build:esm": "tsc --outDir dist/esm && echo '{\"type\":\"module\"}' > dist/esm/package.json",
+    "build:cjs": "tsc --project tsconfig.cjs.json --outDir dist/commonjs && echo '{\"type\":\"commonjs\"}' > dist/commonjs/package.json",
+    "build": "npm run build:esm && npm run build:cjs",
     "build.parser": "peggy src/parser/grammars/grammar.peggy --output src/parser/parser.js --format es --dts",
     "lint": "npx @biomejs/biome check",
     "type-check": "tsc --noEmit",

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "outDir": "./dist/commonjs",
+    "verbatimModuleSyntax": false,
+    "noEmitHelpers": false,
+    "resolvePackageJsonExports": false,
+    "resolvePackageJsonImports": false
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "allowJs": true,
     "declaration": true,
     "sourceMap": true,
-    "outDir": "./dist",
+    "outDir": "./dist/esm",
     "importHelpers": false,
     "noEmitHelpers": true,
     "noEmitOnError": true,


### PR DESCRIPTION
Hi Jakub, I have been evaluating JSONPath libraries to replace the old `jsonpath` NPM package I am using now. I knew about Nimma from a while back but I was excited to see you are implementing an RFC9535 successor. One issue I encountered is that the package is built as ESM-only which is super refreshing. Sadly I do need to support CommonJS users (I hope not for long...). I was wondering if you'd be interested in a PR to add dual bundling support. I don't have an immediate need for this and I'm happy to close the draft PR if it's creating noise or straight up an unwanted "feature" (if you could call cjs that).