### PR TITLE
Remove the src folder from the final npm package build

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,10 @@
     "node": ">=20"
   },
   "files": [
-    "src",
-    "dist"
+    "dist/",
+    "package.json",
+    "LICENSE",
+    "README.md"
   ],
   "type": "module",
   "types": "./dist/esm/index.d.ts",


### PR DESCRIPTION
This minor PR _should_ remove the src folder from the final package while continuing to bundle the expected files and folders. 

I'm not sure how the package contents on npm currently doesn't reflect what is in `package.json` but this is the expected way to choose which files and folders to bundle