### PR TITLE
Change to a CJS fallback instead of ESM fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "dist"
   ],
   "type": "module",
-  "types": "./dist/esm/index.d.ts",
-  "module": "./dist/esm/index.js",
+  "types": "./dist/cjs/index.d.ts",
+  "main": "./dist/cjs/indjex.js",
   "exports": {
     ".": {
       "import": {


### PR DESCRIPTION
So the dual package setup within this project currently has a fallback for ESM projects which are using legacy node module resolution settings. 
```
"module": "./dist/esm/index.js",
```
However, I believe such projects are _incredibly_ rare given that good node ESM support has been something very recent and the legacy node module resolution issue was resolved many years before that point. As such, most ESM projects are likely using modern configuration settings, or can fairly easily migrate to modern configuration settings.

More commonly it is old CJS projects which are using legacy node module resolution settings and are in no position to update.

Still, this is technically a breaking change, so this is your call, but I believe the percentage of CJS users impacted by not having a CJS fallback is far higher than ESM.